### PR TITLE
fixing /healthz http code; using alpine instead of the golang 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,11 @@ COPY controller controller
 COPY exposestrategy exposestrategy
 RUN go build -o exposecontroller
 
-FROM golang as production-stage
+FROM alpine as production-stage
 LABEL MAINTAINER="Aurelien Lambert <aure@olli-ai.com>"
 
 COPY --from=build-stage /app/exposecontroller /exposecontroller
+RUN apk --no-cache upgrade && \
+    mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 
+
 ENTRYPOINT  ["/exposecontroller", "--daemon"]

--- a/exposecontroller.go
+++ b/exposecontroller.go
@@ -233,15 +233,15 @@ func registerHandlers(controller cache.Controller) {
 		ready := controller.HasSynced()
 
 		if ready {
-			res.WriteHeader(http.StatusServiceUnavailable)
-		} else {
 			res.WriteHeader(http.StatusOK)
+			enc := json.NewEncoder(res)
+			_ = enc.Encode(map[string]interface{}{
+				"ready": ready,
+			})
+		} else {
+			res.WriteHeader(http.StatusServiceUnavailable)
 		}
 
-		enc := json.NewEncoder(res)
-		_ = enc.Encode(map[string]interface{}{
-			"ready": ready,
-		})
 	})
 
 	if *profiling {


### PR DESCRIPTION
The current golang has a critical vulnerability CVE-2019-19814 hence using stock standard alpine for the production stage.